### PR TITLE
Add check for missing spells in data

### DIFF
--- a/Spy/Libs/UnitCasting-1.1/UnitCasting-1.1.lua
+++ b/Spy/Libs/UnitCasting-1.1/UnitCasting-1.1.lua
@@ -308,7 +308,7 @@ local newIBuff = function(caster, buff)
 end
 
 local function manageDR(time, tar, b, castOn)
-	if not uc.BuffsToTrack[b]['dr'] then return 1 end
+	if not uc.BuffsToTrack[b] or not uc.BuffsToTrack[b]['dr'] then return 1 end
 
 	for k, v in pairs(dreturnsList) do
 		if v.target == tar and v.type == uc.BuffsToTrack[b]['dr'] then


### PR DESCRIPTION
Rupture ability causes an error when script attempts to get `['dr']` data from `uc.BuffsToTrack[b]` but this spell not in there.
![image](https://user-images.githubusercontent.com/31561525/204882050-f345ce5a-d657-4a06-ab42-2c474d5953a9.png)
![image](https://user-images.githubusercontent.com/31561525/204961147-cd737df0-f118-438b-9e14-b7f962534b2d.png)
